### PR TITLE
Ensure properly formatted code

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,9 @@
+[
+  inputs: [
+    "config/*.{ex,exs}",
+    "test/**/*.{ex,exs}",
+    "lib/**/*.{ex,exs}",
+    "mix.exs",
+    ".formatter.exs"
+  ]
+]

--- a/lib/test/action_test.ex
+++ b/lib/test/action_test.ex
@@ -21,7 +21,7 @@ defmodule Frankt.ActionTest do
   After pushing the message to Frankt you can check the response by using
   `Phoenix.ChannelTest.assert_push/3`.
   """
-  @spec frankt_action(socket :: Socket.t, action :: String.t, payload :: map()) :: reference()
+  @spec frankt_action(socket :: Socket.t(), action :: String.t(), payload :: map()) :: reference()
   defmacro frankt_action(socket, action, payload \\ %{}) do
     quote do
       push(unquote(socket), "frankt-action", %{action: unquote(action), data: unquote(payload)})

--- a/mix.exs
+++ b/mix.exs
@@ -9,17 +9,17 @@ defmodule Frankt.Mixfile do
       elixir: "~> 1.5",
       source_url: "https://github.com/acutario/frankt",
       homepage_url: "https://github.com/acutario/frankt",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      docs: docs(),
+      docs: docs()
     ]
   end
 
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger]
     ]
   end
 
@@ -27,14 +27,14 @@ defmodule Frankt.Mixfile do
   defp deps do
     [
       {:gettext, "~> 0.13", optional: true},
-      {:ex_doc, "~> 0.18.1", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.18.1", only: :dev, runtime: false}
     ]
   end
 
   defp package do
     [
       licenses: ["MIT"],
-      files: ~w(lib priv LICENSE mix.exs package.json README.md),
+      files: ~w(lib priv LICENSE mix.exs package.json README.md)
     ]
   end
 
@@ -44,9 +44,9 @@ defmodule Frankt.Mixfile do
       extras: [
         "README.md": [filename: "README.md", title: "Introduction"],
         "guides/Concepts.md": [],
-        "guides/Examples.md": [],
+        "guides/Examples.md": []
       ],
-      main: "README.md",
+      main: "README.md"
     ]
   end
 end


### PR DESCRIPTION
Configure the [Mix formatter][1] to properly format the project code files.

[1]: https://hexdocs.pm/mix/Mix.Tasks.Format.html