### PR TITLE
Setup test suite

### DIFF
--- a/.ebert.yml
+++ b/.ebert.yml
@@ -1,0 +1,5 @@
+engines:
+  credo:
+    enabled: true
+pull_requests:
+  comments: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: elixir
+elixir: 1.6
+before_script:
+  - mix compile --warnings-as-errors
+  - mix format --check-formatted
+script:
+  - mix test

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,30 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :frankt, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:frankt, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"
+if Mix.env() == :test, do: import_config("test.exs")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,9 @@
+use Mix.Config
+
+config :frankt, Frankt.TestApplication.Endpoint,
+  pubsub: [name: Frankt.TestApplication.PubSub, adapter: Phoenix.PubSub.PG2]
+
+config :frankt, Frankt.TestApplication.FranktChannel,
+  handlers: [
+    frankt_actions: Frankt.TestApplication.FranktActions
+  ]

--- a/mix.exs
+++ b/mix.exs
@@ -26,6 +26,7 @@ defmodule Frankt.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:phoenix, "~> 1.3"},
       {:gettext, "~> 0.13", optional: true},
       {:ex_doc, "~> 0.18.1", only: :dev, runtime: false}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,8 @@ defmodule Frankt.Mixfile do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),
-      docs: docs()
+      docs: docs(),
+      elixirc_paths: elixirc_paths(Mix.env())
     ]
   end
 
@@ -50,4 +51,8 @@ defmodule Frankt.Mixfile do
       main: "README.md"
     ]
   end
+
+  # Specifies paths to compile per environment.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_env), do: ["lib"]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,10 @@
-%{"earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
+%{
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "gettext": {:hex, :gettext, "0.14.0", "1a019a2e51d5ad3d126efe166dcdf6563768e5d06c32a99ad2281a1fa94b4c72", [], [], "hexpm"}}
+  "gettext": {:hex, :gettext, "0.14.0", "1a019a2e51d5ad3d126efe166dcdf6563768e5d06c32a99ad2281a1fa94b4c72", [], [], "hexpm"},
+  "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.3.2", "2a00d751f51670ea6bc3f2ba4e6eb27ecb8a2c71e7978d9cd3e5de5ccf7378bd", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.0", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.3.3 or ~> 1.4", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/test/frankt/channels/room_channel_test.exs
+++ b/test/frankt/channels/room_channel_test.exs
@@ -1,0 +1,19 @@
+defmodule Frankt.TestApplication.FranktChannelTest do
+  use Frankt.ChannelCase
+
+  alias Frankt.TestApplication.FranktChannel
+
+  setup do
+    {:ok, _, socket} =
+      "frankt_test_socket"
+      |> socket(%{})
+      |> subscribe_and_join(FranktChannel, "frankt:test")
+
+    {:ok, socket: socket}
+  end
+
+  test "runs a Frankt action", %{socket: socket} do
+    frankt_action(socket, "frankt_actions:redirect", %{})
+    assert_push("redirect", %{target: "/"})
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,0 +1,14 @@
+defmodule Frankt.ChannelCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # Import conveniences for testing with channels
+      use Phoenix.ChannelTest
+      use Frankt.ActionTest
+
+      # The default endpoint for testing
+      @endpoint Frankt.TestApplication.Endpoint
+    end
+  end
+end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -1,4 +1,6 @@
 defmodule Frankt.ChannelCase do
+  @moduledoc false
+
   use ExUnit.CaseTemplate
 
   using do

--- a/test/support/test_application.ex
+++ b/test/support/test_application.ex
@@ -1,4 +1,6 @@
 defmodule Frankt.TestApplication do
+  @moduledoc false
+
   use Application
 
   alias Frankt.TestApplication.Endpoint

--- a/test/support/test_application.ex
+++ b/test/support/test_application.ex
@@ -1,0 +1,10 @@
+defmodule Frankt.TestApplication do
+  use Application
+
+  alias Frankt.TestApplication.Endpoint
+
+  def start(_type, _args) do
+    children = [{Endpoint, []}]
+    Supervisor.start_link(children, strategy: :one_for_one, name: __MODULE__)
+  end
+end

--- a/test/support/test_application/endpoint.ex
+++ b/test/support/test_application/endpoint.ex
@@ -1,4 +1,6 @@
 defmodule Frankt.TestApplication.Endpoint do
+  @moduledoc false
+
   use Phoenix.Endpoint, otp_app: :frankt
 
   socket("/socket", Frankt.TestApplication.Socket)

--- a/test/support/test_application/endpoint.ex
+++ b/test/support/test_application/endpoint.ex
@@ -1,0 +1,9 @@
+defmodule Frankt.TestApplication.Endpoint do
+  use Phoenix.Endpoint, otp_app: :frankt
+
+  socket("/socket", Frankt.TestApplication.Socket)
+
+  def init(_key, config) do
+    {:ok, config}
+  end
+end

--- a/test/support/test_application/frankt_actions.ex
+++ b/test/support/test_application/frankt_actions.ex
@@ -1,0 +1,7 @@
+defmodule Frankt.TestApplication.FranktActions do
+  import Phoenix.Channel
+
+  def redirect(_params, socket) do
+    push(socket, "redirect", %{target: "/"})
+  end
+end

--- a/test/support/test_application/frankt_actions.ex
+++ b/test/support/test_application/frankt_actions.ex
@@ -1,4 +1,6 @@
 defmodule Frankt.TestApplication.FranktActions do
+  @moduledoc false
+
   import Phoenix.Channel
 
   def redirect(_params, socket) do

--- a/test/support/test_application/frankt_channel.ex
+++ b/test/support/test_application/frankt_channel.ex
@@ -1,0 +1,7 @@
+defmodule Frankt.TestApplication.FranktChannel do
+  use Phoenix.Channel
+
+  use Frankt
+
+  def join("frankt:" <> _identifier, _payload, socket), do: {:ok, socket}
+end

--- a/test/support/test_application/frankt_channel.ex
+++ b/test/support/test_application/frankt_channel.ex
@@ -1,4 +1,6 @@
 defmodule Frankt.TestApplication.FranktChannel do
+  @moduledoc false
+
   use Phoenix.Channel
 
   use Frankt

--- a/test/support/test_application/socket.ex
+++ b/test/support/test_application/socket.ex
@@ -1,4 +1,6 @@
 defmodule Frankt.TestApplication.Socket do
+  @moduledoc false
+
   use Phoenix.Socket
 
   channel("room:*", Frankt.TestApplication.FranktChannel)

--- a/test/support/test_application/socket.ex
+++ b/test/support/test_application/socket.ex
@@ -1,0 +1,11 @@
+defmodule Frankt.TestApplication.Socket do
+  use Phoenix.Socket
+
+  channel("room:*", Frankt.TestApplication.FranktChannel)
+
+  transport(:websocket, Phoenix.Transports.WebSocket)
+
+  def connect(_params, socket), do: {:ok, socket}
+
+  def id(_socket), do: nil
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,13 @@
+# We must ensure that the Frankt action modules are properly loaded. I don't
+# really know if this could be done in a better way but, until I find out, this
+# works fine.
+:frankt
+|> Application.get_env(Frankt.TestApplication.FranktChannel)
+|> Keyword.get(:handlers, [])
+|> Keyword.values()
+|> Enum.each(&Code.ensure_loaded/1)
+
+# Our Phoenix test application must be started before running the tests.
+Frankt.TestApplication.start(:normal, [])
+
 ExUnit.start()


### PR DESCRIPTION
This PR resolves #2 

The main objective of this PR is to set up the test suite for Frankt. At the moment the test suite is composed by:
- A test Phoenix application which lives in `test/support/test_application`.
- A single test case (I'll explain later why there is only one) which lives in `test/frankt`.

It is noteworthy that the test suite is composed by a single case. I've tried to check other possibilities when using Frankt, specially the ones that may cause errors. Turns out that with the current approach, we can not test them. The explanation of this can be found in issue #8.

Testing the runtime errors would require some extra work and a change in how Frankt reads the configuration and works. I've choosen to keep this PR focused on setting up the test suite only, and improve it iteratively on separated PRs.

The tasks done for this PR are

- [x] Create a test application for Frankt.
- [x] Test calling a registered handler.
- [x] Set up integration with [Ebert][1]
- [x] Set up integration with [TravisCI][2] 

[1]: https://ebertapp.io/
[2]: https://travis-ci.com/