### PR TITLE
Retrieve stacktrace when rescuing the error

### DIFF
--- a/test/support/test_application/frankt_custom_error_channel.ex
+++ b/test/support/test_application/frankt_custom_error_channel.ex
@@ -11,7 +11,7 @@ defmodule Frankt.TestApplication.FranktCustomErrorChannel do
     %{"frankt_actions" => Frankt.TestApplication.FranktActions}
   end
 
-  def handle_error(_error, socket, _params) do
+  def handle_error(_error, stacktrace, socket, _params) do
     push(socket, "custom-error-handled", %{})
     {:noreply, socket}
   end


### PR DESCRIPTION
The root of the problem is that Frankt users who implement their own `handle_error/3` callback had to obtain the error stacktrace to properly report it.
Elixir 1.7 introduces the [new `__STACKTRACE__` construct][1] and deprecates calls to `System.stacktrace/0` outside of `rescue`/`catch` blocks. Since the Frankt users code is not executed in the  `rescue` clause, the compilation of their projects emits some deprecation warnings.

To avoid warnings when compiling Frankt on Elixir 1.7 we have two options:
* Substitute calls to `System.stacktrace/0` with `__STACKTRACE__`. **Which would only support Elixir 1.7 and higher.**
* Call `System.stacktrace/0` inside `rescue`/`catch` blocks. **Which is not deprecated and backwards compatible.**

Since we want Frankt to support a wide range of Elixir versions, we have opted for the second option. When an error happens, Frankt retrieves the corresponding stacktrace by calling `System.stacktrace/0` in the `rescue` sentence. **The stacktrace is then passed as an argument to the error handler.**

This pull request breaks Frankt's public API since it adds a new argument to the `handle_error` callback, but has the benefit of providing clean compilations on future Elixir versions. Since we haven't reached 1.0 yet, it is the moment to apply this kind of breaking changes.

[1]: https://github.com/elixir-lang/elixir/blob/v1.7/CHANGELOG.md#the-__stacktrace__-construct